### PR TITLE
Subscribe to close event on connect and connectTo

### DIFF
--- a/src/core/index.tsx
+++ b/src/core/index.tsx
@@ -72,6 +72,7 @@ export class Core {
     new Promise(async (resolve, reject) => {
       this.on(CONNECT_EVENT, provider => resolve(provider));
       this.on(ERROR_EVENT, error => reject(error));
+      this.on(CLOSE_EVENT, () => reject('Modal closed by user));
       await this.toggleModal();
     });
 
@@ -79,6 +80,7 @@ export class Core {
     new Promise(async (resolve, reject) => {
       this.on(CONNECT_EVENT, provider => resolve(provider));
       this.on(ERROR_EVENT, error => reject(error));
+      this.on(CLOSE_EVENT, () => reject('Modal closed by user));
       const provider = this.providerController.getProvider(id);
       if (!provider) {
         return reject(


### PR DESCRIPTION
I don't think #150 is completely fixed by v1.6.0, as it currently only rejects the promise on an error event. Closing the dialog by clicking elsewhere on the page does not reject the promise.

I have not tested these changes locally but believe they should work