### PR TITLE
Add qrcodeModalOptions to WalletConnect

### DIFF
--- a/src/providers/connectors/walletconnect.ts
+++ b/src/providers/connectors/walletconnect.ts
@@ -26,6 +26,7 @@ const ConnectToWalletConnect = (
       rpc = opts.rpc || undefined;
       chainId =
         opts.network && getChainId(opts.network) ? getChainId(opts.network) : 1;
+      qrcodeModalOptions = opts.qrcodeModalOptions || undefined;
     }
 
     const provider = new WalletConnectProvider({


### PR DESCRIPTION
WalletConnect constructor misses the options for the QRCode modal