### PR TITLE
Increase zIndex to 9999

### DIFF
--- a/example/src/components/Modal.tsx
+++ b/example/src/components/Modal.tsx
@@ -18,7 +18,7 @@ const SLightbox = styled.div<ILightboxStyleProps>`
   margin-left: -50vw;
   top: ${({ offset }) => (offset ? `-${offset}px` : 0)};
   left: 50%;
-  z-index: 2;
+  z-index: 9999;
   will-change: opacity;
   background-color: ${({ opacity }) => {
     let alpha = 0.4

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -35,7 +35,7 @@ const SLightbox = styled.div<ILightboxStyleProps>`
   margin-left: -50vw;
   top: ${({ offset }) => (offset ? `-${offset}px` : 0)};
   left: 50%;
-  z-index: 2;
+  z-index: 9999;
   will-change: opacity;
   background-color: ${({ opacity }) => {
     let alpha = 0.4;


### PR DESCRIPTION
Chakra-UI and many other libraries use a zIndex higher than 2 for many components, tooltips, etc, which block web3modal. 

Increasing zIndex will allow the modal to be used in more situations and not be blocked by other components. 