### PR TITLE
Replace deprecated metamask API method

### DIFF
--- a/src/providers/connectors/injected.ts
+++ b/src/providers/connectors/injected.ts
@@ -1,9 +1,9 @@
 const ConnectToInjected = async () => {
   let provider = null;
-  if (window.ethereum) {
+  if (typeof window.ethereum !== 'undefined') {
     provider = window.ethereum;
     try {
-      await window.ethereum.enable();
+      await provider.request({ method: 'eth_requestAccounts' })
     } catch (error) {
       throw new Error("User Rejected");
     }


### PR DESCRIPTION
Address: [#206](https://github.com/Web3Modal/web3modal/issues/206)
The injected connector is using a deprecated method as described in the metamask specs:
https://docs.metamask.io/guide/ethereum-provider.html#legacy-methods