### PR TITLE
Add a better check for localStorage availability

### DIFF
--- a/src/helpers/local.ts
+++ b/src/helpers/local.ts
@@ -1,9 +1,8 @@
+import { isLocalStorageAvailable } from "./utils";
+
 export let local: Storage;
 
-if (
-  typeof window !== "undefined" &&
-  typeof window.localStorage !== "undefined"
-) {
+if (isLocalStorageAvailable()) {
   local = window.localStorage;
 }
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -228,3 +228,14 @@ export function findMatchingRequiredOptions(
   });
   return matches;
 }
+
+export function isLocalStorageAvailable(): boolean {
+  var test = "test";
+  try {
+    localStorage.setItem(test, test);
+    localStorage.removeItem(test);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -230,7 +230,7 @@ export function findMatchingRequiredOptions(
 }
 
 export function isLocalStorageAvailable() {
-  var test = "test";
+  let test = "test";
   try {
     localStorage.setItem(test, test);
     localStorage.removeItem(test);

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -229,7 +229,7 @@ export function findMatchingRequiredOptions(
   return matches;
 }
 
-export function isLocalStorageAvailable(): boolean {
+export function isLocalStorageAvailable() {
   var test = "test";
   try {
     localStorage.setItem(test, test);


### PR DESCRIPTION
When cookies are disabled, browsers (at least chromium based browser) throw an error when you try to access localStorage.

localStorage is no longer just undefined, but it triggers an error that stop web3modal from working entirely.

You can reproduce this by disabling cookies on your browser and visit https://web3modal.com you will see a white page with this error in the console: `Uncaught DOMException: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.`

To fix this, we can check differently with a try catch that will try to use localStorage and return true or false depending on whether it works or not.