### PR TITLE
add dynamic import 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ lib
 
 yarn.lock
 .eslintcache
+
+.idea

--- a/README.md
+++ b/README.md
@@ -143,6 +143,24 @@ These are all the providers available with Web3Modal and how to configure their 
 - [BurnerConnect](./docs/providers/burnerconnect.md)
 - [MEWConnect](./docs/providers/mewconnect.md)
 
+### Importing providers dynamically
+
+For the options above you will be asked to provide a `package`. You may optionally import
+those packages dynamically so that you only import the ones the user actually uses. You 
+just need to provide a function that returns a dynamic import of the package, and set 
+`packageFactory` to true, e.g:
+
+```
+  providerOptions: {
+    walletconnect: {
+      package: () => import('@walletconnect/web3-provider'),
+      packageFactory: true,
+      options: {
+        infuraId: INFURA_ID
+      }
+    }
+```
+
 ## API
 
 ```typescript

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -195,8 +195,17 @@ export class ProviderController {
     connector: (providerPackage: any, opts: any) => Promise<any>
   ) => {
     try {
-      const providerPackage = this.getProviderOption(id, "package");
+      let providerPackage = this.getProviderOption(id, "package");
       const providerOptions = this.getProviderOption(id, "options");
+      const packageFactory = this.getProviderOption(id, "packageFactory");
+
+      if(packageFactory === true) {
+        providerPackage = await providerPackage();
+        if(providerPackage.default) {
+          providerPackage = providerPackage.default;
+        }
+      }
+
       const opts = { network: this.network || undefined, ...providerOptions };
       const provider = await connector(providerPackage, opts);
       this.eventController.trigger(CONNECT_EVENT, provider);


### PR DESCRIPTION
Hey, 

Ive added some changes to allow dynamic imports of the provider packages 

The consumer would use this feature as follows 

```
  providerOptions: {
    walletconnect: {
      package: () => import('@walletconnect/web3-provider'),
      packageFactory: true,
      options: {
        infuraId: INFURA_ID
      }
    },
```

When packageFactory is true package will be treated as a function that returns a promise for the provider package 