### PR TITLE
README: Add required network-options for Fortmatic-provider

### DIFF
--- a/docs/providers/fortmatic.md
+++ b/docs/providers/fortmatic.md
@@ -15,11 +15,18 @@ yarn add fortmatic
 ```typescript
 import Fortmatic from "fortmatic";
 
+// Example for Polygon/Matic:
+const customNetworkOptions = {
+    rpcUrl: 'https://rpc-mainnet.maticvigil.com',
+    chainId: 137
+}
+
 const providerOptions = {
   fortmatic: {
     package: Fortmatic, // required
     options: {
-      key: "FORTMATIC_KEY" // required
+      key: "FORTMATIC_KEY" // required,
+      network: customNetworkOptions // if we don't pass it, it will default to localhost:8454
     }
   }
 };


### PR DESCRIPTION
Docs only, no code changes, no compatibility break.

Fixes #371 with adding *required* network options to Fortmatic. Without these settings, Formatic will default to connecting to `localhost:8454`

