### PR TITLE
Remove nested array typo from walletlink required packages field

### DIFF
--- a/src/providers/providers/index.ts
+++ b/src/providers/providers/index.ts
@@ -153,6 +153,6 @@ export const WALLETLINK: IProviderInfo = {
   type: "qrcode",
   check: "isWalletLink",
   package: {
-    required: [["appName", "infuraId", "rpc"]]
+    required: ["appName", "infuraId", "rpc"]
   }
 };


### PR DESCRIPTION
WalletLink does not render because required options are never recognized as present due to being nested within an extraneous array.

Closes #386 