### PR TITLE
Update to CoinbaseWalletSDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ These are all the providers available with Web3Modal and how to configure their 
 - [BurnerConnect](./docs/providers/burnerconnect.md)
 - [MEWConnect](./docs/providers/mewconnect.md)
 - [Binance Chain Wallet](./docs/providers/binancechainwallet.md)
-- [WalletLink](./docs/providers/walletlink.md)
+- [CoinbaseWallet](./docs/providers/walletlink.md)
 
 ## API
 

--- a/docs/providers/walletlink.md
+++ b/docs/providers/walletlink.md
@@ -1,33 +1,37 @@
-# WalletLink
+# Coinbase Wallet SDK
 
 1. Install Provider Package
 
 ```bash
-npm install --save walletlink
+npm install --save @coinbase/wallet-sdk
 
 # OR
 
-yarn add walletlink
+yarn add @coinbase/wallet-sdk
 ```
 
 2. Set Provider Options
 
 ```typescript
-import WalletLink from "walletlink";
+import CoinbaseWalletSDK from '@coinbase/wallet-sdk';
+import WalletConnect from "@walletconnect/web3-provider";
 
 const providerOptions = {
   walletlink: {
-    package: WalletLink, // Required
+    package: CoinbaseWalletSDK, // Required
     options: {
       appName: "My Awesome App", // Required
-      infuraId: "INFURA_ID", // Required unless you provide a JSON RPC url; see `rpc` below
-      rpc: "", // Optional if `infuraId` is provided; otherwise it's required
-      chainId: 1, // Optional. It defaults to 1 if not provided
-      appLogoUrl: null, // Optional. Application logo image URL. favicon is used if unspecified
+      infuraId: "INFURA_ID", // Required
       darkMode: false // Optional. Use dark theme, defaults to false
     }
+  },
+  walletconnect: {
+   package: WalletConnect, 
+   options: {
+      infuraId: "INFURA_ID",
+   }
   }
 };
 ```
 
-[For more information on WalletLink Web3 provider](https://github.com/walletlink/walletlink).
+[For more information on CoinbaseWallet Web3 provider](https://docs.cloud.coinbase.com/wallet-sdk/docs).

--- a/example/package.json
+++ b/example/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "7.12.3",
+    "@coinbase/wallet-sdk": "^3.0.4",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.2",
     "@svgr/webpack": "5.4.0",
     "@testing-library/jest-dom": "^5.11.4",
@@ -77,7 +78,6 @@
     "ts-pnp": "1.2.0",
     "typescript": "^4.0.3",
     "url-loader": "4.1.1",
-    "walletlink": "^2.4.0",
     "web-vitals": "^0.2.4",
     "web3": "^1.3.1",
     "web3modal": "file:..",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -9,7 +9,7 @@ import WalletConnect from "@walletconnect/web3-provider";
 // @ts-ignore
 import Torus from "@toruslabs/torus-embed";
 // @ts-ignore
-import WalletLink from "walletlink";
+import CoinbaseWalletSDK from "@coinbase/wallet-sdk";
 
 import Button from "./components/Button";
 import Column from "./components/Column";
@@ -243,7 +243,7 @@ class App extends React.Component<any, any> {
         package: Torus
       },
       walletlink: {
-        package: WalletLink,
+        package: CoinbaseWalletSDK,
         options: {
           appName: "Web3Modal Example App",
           infuraId

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "torus",
     "authereum",
     "frame",
-    "walletlink"
+    "coinbasewallet"
   ],
   "author": "Web3Modal <web3modal.com>",
   "license": "MIT",


### PR DESCRIPTION
Walletlink is deprecated and renamed to CoinbaseWalletSDK. See: https://github.com/coinbase/coinbase-wallet-sdk