### PR TITLE
feat: added a listener triggered when a provider selected

### DIFF
--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -1,3 +1,4 @@
 export const CONNECT_EVENT = "connect";
 export const ERROR_EVENT = "error";
 export const CLOSE_EVENT = "close";
+export const ON_PROVIDER_SELECT = "onProviderSelect";

--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -2,6 +2,7 @@ import * as list from "../providers";
 import {
   CONNECT_EVENT,
   ERROR_EVENT,
+  ON_PROVIDER_SELECT,
   INJECTED_PROVIDER_ID,
   CACHED_PROVIDER_KEY
 } from "../constants";
@@ -195,6 +196,7 @@ export class ProviderController {
     connector: (providerPackage: any, opts: any) => Promise<any>
   ) => {
     try {
+      this.eventController.trigger(ON_PROVIDER_SELECT, id);
       const providerPackage = this.getProviderOption(id, "package");
       const providerOptions = this.getProviderOption(id, "options");
       const opts = { network: this.network || undefined, ...providerOptions };

--- a/src/core/index.tsx
+++ b/src/core/index.tsx
@@ -12,7 +12,8 @@ import {
   WEB3_CONNECT_MODAL_ID,
   CONNECT_EVENT,
   ERROR_EVENT,
-  CLOSE_EVENT
+  CLOSE_EVENT,
+  ON_PROVIDER_SELECT
 } from "../constants";
 import { themesList } from "../themes";
 import { Modal } from "../components";
@@ -57,6 +58,8 @@ export class Core {
       this.onConnect(provider)
     );
     this.providerController.on(ERROR_EVENT, error => this.onError(error));
+
+    this.providerController.on(ON_PROVIDER_SELECT, this.onProviderSelect);
 
     this.userOptions = this.providerController.getUserOptions();
     this.renderModal();
@@ -178,6 +181,10 @@ export class Core {
       await this._toggleModal();
     }
     this.eventController.trigger(ERROR_EVENT, error);
+  };
+
+  private onProviderSelect = (providerId: string) => {
+    this.eventController.trigger(ON_PROVIDER_SELECT, providerId);
   };
 
   private onConnect = async (provider: any) => {


### PR DESCRIPTION
Added an event trigger represents the period between a provider selected(clicked) and before the event `CONNECT_EVENT` triggered.

The providers like WalletConnect and Portis, take some extra time to load their own widgets for further actions. This added listener is handy for developers to add the loading indicator or other prompts to indicate provider initialization is ongoing in the background.

### Usage:

```typescript
web3Modal.on("onProviderSelect", providerId => {
    console.log(
        `the on provider select: ${providerId}`
    );
});
```

