### PR TITLE
update coinbase wallet copy

### DIFF
--- a/src/providers/injected/index.ts
+++ b/src/providers/injected/index.ts
@@ -111,7 +111,7 @@ export const TRUST: IProviderInfo = {
 
 export const COINBASE: IProviderInfo = {
   id: "injected",
-  name: "Coinbase",
+  name: "Coinbase Wallet",
   logo: CoinbaseLogo,
   type: "injected",
   check: "isCoinbaseWallet"

--- a/src/providers/providers/index.ts
+++ b/src/providers/providers/index.ts
@@ -166,7 +166,7 @@ export const WALLETLINK: IProviderInfo = {
 
 export const COINBASEWALLET: IProviderInfo = {
   id: "coinbasewallet",
-  name: "Coinbase",
+  name: "Coinbase Wallet",
   logo: CoinbaseWalletLogo,
   type: "injected",
   check: "isWalletLink",


### PR DESCRIPTION
@TrevvvD from Coinbase requested that the copy on the Provider.name be changed from `Coinbase` to `Coinbase Wallet` 
![image](https://user-images.githubusercontent.com/80423742/166257329-d272ba51-9659-4753-b503-0d19648e3d5c.png)

to make it clear that users can connect with the Coinbase Wallet extension as opposed to Coinbase retail app.