### PR TITLE
fix: ESLint configuration invalid

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,6 @@
 {
   "parser": "babel-eslint",
   "extends": "eslint:recommended",
-  "quotes": "double",
   "rules": {
     "space-before-function-paren": ["error", "never"],
     "semi": ["error", "never"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,6 @@
     "space-before-function-paren": ["error", "never"],
     "semi": ["error", "never"],
     "no-underscore-dangle": 0,
-    "quotes": ["error", "single"]
+    "quotes": ["error", "double"]
   }
 }


### PR DESCRIPTION
```
Error: ESLint configuration in .eslintrc is invalid:
	- Unexpected top-level property "quotes".
```